### PR TITLE
feat: Add user roles and admin user list endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     ports:
       - "3000:3000"
+      - "5555:5555"
     volumes:
       - ./src:/usr/src/app/src
     environment:

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -6,7 +6,6 @@ class AuthController {
   async register(req, res) {
     try {
       const user = await AuthService.register(req.body);
-      // Não retorna a senha no response
       const { password, ...userWithoutPassword } = user;
       res.status(201).json(userWithoutPassword);
     } catch (error) {
@@ -23,14 +22,22 @@ class AuthController {
     }
   }
 
-  // --- NOVA FUNÇÃO ADICIONADA ---
   async getProfile(req, res) {
     try {
-      // O ID do usuário (req.user.id) é adicionado à requisição pelo authMiddleware
       const userProfile = await AuthService.getProfile(req.user.id);
       res.status(200).json(userProfile);
     } catch (error) {
       res.status(404).json({ message: error.message });
+    }
+  }
+
+  // --- NOVA FUNÇÃO PARA ADMINS ---
+  async getAllUsers(req, res) {
+    try {
+      const users = await AuthService.getAllUsers();
+      res.status(200).json(users);
+    } catch (error) {
+      res.status(500).json({ message: 'Erro ao buscar usuários.' });
     }
   }
 }

--- a/src/middleware/admin.middleware.js
+++ b/src/middleware/admin.middleware.js
@@ -1,0 +1,18 @@
+// src/middleware/admin.middleware.js
+
+function adminMiddleware(req, res, next) {
+  // Este middleware DEVE ser executado DEPOIS do authMiddleware,
+  // pois ele depende do req.user que o authMiddleware cria.
+  
+  const { role } = req.user;
+
+  if (role !== 'ADMIN') {
+    // Se o usuário não for um administrador, bloqueia o acesso.
+    return res.status(403).json({ message: 'Acesso negado. Rota exclusiva para administradores.' });
+  }
+
+  // Se o usuário for um administrador, permite que a requisição continue.
+  return next();
+}
+
+module.exports = adminMiddleware;

--- a/src/middleware/auth.middleware.js
+++ b/src/middleware/auth.middleware.js
@@ -1,4 +1,4 @@
-// src/middlewares/auth.middleware.js
+// src/middleware/auth.middleware.js
 
 const jwt = require('jsonwebtoken');
 
@@ -13,10 +13,14 @@ function authMiddleware(req, res, next) {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    const { id, email } = decoded;
+    
+    // --- A CORREÇÃO CRÍTICA ESTÁ AQUI ---
+    // Agora extraímos o 'role' do token decodificado
+    const { id, email, role } = decoded;
 
-    // Adiciona os dados do usuário ao objeto 'req' para uso posterior
-    req.user = { id, email };
+    // E adicionamos o 'role' ao objeto 'req.user'
+    req.user = { id, email, role };
+    // ------------------------------------
 
     return next();
   } catch (error) {

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -3,16 +3,19 @@
 const { Router } = require('express');
 const AuthController = require('../controllers/auth.controller');
 const authMiddleware = require('../middleware/auth.middleware');
+const adminMiddleware = require('../middleware/admin.middleware'); // Importa o novo middleware
 
 const router = Router();
 
 // --- ROTAS PÚBLICAS ---
-// Qualquer um pode tentar se registrar ou fazer login
 router.post('/auth/register', AuthController.register);
 router.post('/auth/login', AuthController.login);
 
-// --- ROTA PROTEGIDA ---
-// Apenas usuários com um token válido podem acessar seu próprio perfil
+// --- ROTA DE USUÁRIO LOGADO ---
 router.get('/auth/profile', authMiddleware, AuthController.getProfile);
+
+// --- NOVA ROTA DE ADMIN ---
+// A requisição passa primeiro pelo authMiddleware, depois pelo adminMiddleware, e só então chega ao controller.
+router.get('/admin/users', authMiddleware, adminMiddleware, AuthController.getAllUsers);
 
 module.exports = router;


### PR DESCRIPTION
Updated the Prisma schema with a 'Role' enum and added the 'role' field to the User model. Implemented an admin middleware and a protected route GET /admin/users to list all users. The JWT payload now includes the user's role.